### PR TITLE
Update CPR

### DIFF
--- a/libs/_linux/cpr/cpr.py
+++ b/libs/_linux/cpr/cpr.py
@@ -6,16 +6,16 @@ class subinfo(info.infoclass):
     def setTargets(self):
         self.description = "C++ Requests: Curl for People, a spiritual port of Python Requests."
 
-        for ver in ["1.7.2"]:
+        for ver in ["1.8.3"]:
             self.targets[ver] = f"https://github.com/libcpr/cpr/archive/refs/tags/{ver}.tar.gz"
             self.targetInstSrc[ver] = f"cpr-{ver}"
 
-        self.targetDigests["1.7.2"] = (
-            ["aa38a414fe2ffc49af13a08b6ab34df825fdd2e7a1213d032d835a779e14176f"],
+        self.targetDigests["1.8.3"] = (
+            ["0784d4c2dbb93a0d3009820b7858976424c56578ce23dcd89d06a1d0bf5fd8e2"],
             CraftHash.HashAlgorithm.SHA256,
         )
 
-        self.defaultTarget = "1.7.2"
+        self.defaultTarget = "1.8.3"
 
     def setDependencies(self):
         self.runtimeDependencies["libs/libcurl"] = None


### PR DESCRIPTION
Should fix problems with the AppImage updater. Due to some library incompatibility (which could not be detected during build time, but only showed during runtime with unexpected error messages), the updater could not make requests to some HTTPS servers, most notably our download mirrors.