### PR TITLE
Remove optimisation hack

### DIFF
--- a/owncloud/owncloud-client/owncloud-client.py
+++ b/owncloud/owncloud-client/owncloud-client.py
@@ -130,16 +130,6 @@ class Package(CMakePackageBase):
         cmdRe = re.compile(r".*cmd")
         crashReporterRe = re.compile(r".*_crash_reporter")
 
-        appDsymDir = Path(CraftCore.standardDirs.craftRoot()) / "Applications/KDE/*.app.dSYM/Contents/Resources/DWARF"
-        hack = []
-        for exp in ["FinderSyncExt", "*cmd", "*_crash_reporter"]:
-            hack += glob.glob(str(appDsymDir / exp))
-
-        for f in hack:
-            CraftCore.log.warning(f'dump_symbols: {f} is removed')
-            os.remove(f)
-        print(hack)
-
         for binaryFile in binaryFiles:
             binaryFile = Path(binaryFile)
             if CraftCore.compiler.isWindows and icuRe.match(binaryFile.name):


### PR DESCRIPTION
The file structure changed with recent craft changes and removing f failed. Additionally this is modifying files in the install root, noot a good idea in general. As this looks like it was intended to speed up packaging by a few seconds... remove it.