### PR TITLE
Make AppRun script a template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 
 # editor backups
 *.*swp*
+
+AppRun.sh

--- a/owncloud/owncloud-client/AppRun.sh.in
+++ b/owncloud/owncloud-client/AppRun.sh.in
@@ -6,7 +6,7 @@ this_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "${1:-}" == "--cmd" ]]; then
     shift
-    exec "$this_dir"/usr/bin/owncloudcmd "$@"
+    exec "$this_dir"/usr/bin/@{appname}cmd "$@"
 fi
 
-exec "$this_dir"/usr/bin/owncloud "$@"
+exec "$this_dir"/usr/bin/@{appname} "$@"

--- a/owncloud/owncloud-client/owncloud-client.py
+++ b/owncloud/owncloud-client/owncloud-client.py
@@ -222,7 +222,13 @@ class Package(CMakePackageBase):
         ]
         self.defines["icon"] = Path(self.buildDir()) / "src/gui/owncloud.ico"
         self.defines["pkgproj"] = Path(self.buildDir()) / "admin/osx/macosx.pkgproj"
-        self.defines["appimage_apprun"] = self.packageDir() / "apprun.sh"
+        # TODO: use a temporary directory (or file) to store the generated script
+        assert utils.configureFile(
+            self.packageDir() / "AppRun.sh.in",
+            self.packageDir() / "AppRun.sh",
+            self.defines,
+        )
+        self.defines["appimage_apprun"] = self.packageDir() / "AppRun.sh"
         ver = self.owncloudVersion()
         if ver:
             self.defines["version"] = ver


### PR DESCRIPTION
This PR ensures that the AppRun script included in our AppImages is branded correctly. AppImages for non-`ownCloud` brandings like `testpilotcloud` should work again once this has been merged.