### PR TITLE
use application shortname to create installer icon

### DIFF
--- a/owncloud/owncloud-client/owncloud-client.py
+++ b/owncloud/owncloud-client/owncloud-client.py
@@ -270,7 +270,7 @@ class Package(CMakePackageBase):
                 "description": self.subinfo.description,
             }
         ]
-        self.defines["icon"] = self.buildDir() / "src/gui/owncloud.ico"
+        self.defines["icon"] = self.buildDir() / f'src/gui/{self.applicationShortname.lower().replace("_", "-")}.ico'
         self.defines["pkgproj"] = self.buildDir() / "admin/osx/macosx.pkgproj"
         self.defines["appimage_extra_output"] = ["native_packages"]
         ver = self.owncloudVersion()


### PR DESCRIPTION
When trying to `craft --package owncloud-client` I get this error:
```
Processing config: C:\Users\{...}\ownbuild\ownbuild\5\windows-cl-msvc2022-x86_64\dev-utils\nsis\nsisconf.nsh
Processing script file: "C:\_\fcafd268\owncloud-client.nsi" (ACP)
Error while loading icon from "C:\_\fcafd268\build\src\gui\owncloud.ico": can't open file
Error in macro MUI_INTERFACE on macroline 86
Error in macro MUI_PAGE_INIT on macroline 7
Error in macro MUI_PAGE_WELCOME on macroline 5
Error in script "C:\_\fcafd268\owncloud-client.nsi" on line 98 -- aborting creation process
Command ['C:\\Users\\{...}\\ownbuild\\ownbuild\\5\\windows-cl-msvc2022-x86_64\\dev-utils\\bin\\makensis.exe', '/V3', 'C:\\_\\fcafd268\\owncloud-client.nsi'] failed with exit code 1
Error in makensis execution
Action: package for owncloud/owncloud-client:master FAILED
*** Craft package failed: owncloud/owncloud-client after 22 seconds ***
```

I am using a theme with `craft --set args="-DOEM_THEME_DIR=C:/{...}/ownbuild/junidrive/mirall" owncloud-client`

This PR lets me continue the packaging ;-)